### PR TITLE
delete unneccessary preprocessing steps

### DIFF
--- a/code/preprocessing.sh
+++ b/code/preprocessing.sh
@@ -12,8 +12,8 @@ python -m code.preprocessing.create_labels data/raw/ data/preprocessing/labeled.
 
 # other preprocessing (removing punctuation etc.)
 echo "  general preprocessing"
-python -m code.preprocessing.run_preprocessing data/preprocessing/labeled.csv data/preprocessing/preprocessed.csv --punctuation --tokenize --count -e data/preprocessing/pipeline.pickle
-
+python -m code.preprocessing.run_preprocessing data/preprocessing/labeled.csv data/preprocessing/preprocessed.csv --count -e data/preprocessing/pipeline.pickle
+# right now not using these preprocessing methods, so exclude them: --punctuation ; --tokenize
 # split the data set
 echo "  splitting the data set"
 python -m code.preprocessing.split_data data/preprocessing/preprocessed.csv data/preprocessing/split/ -s 42


### PR DESCRIPTION
delete preprocessing steps "punctuation" and "tokenize" because none of
the features use them.